### PR TITLE
refactor(launch): delete launch and launch--glyph

### DIFF
--- a/src/svg/launch--glyph.svg
+++ b/src/svg/launch--glyph.svg
@@ -1,5 +1,0 @@
-
-<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill-rule="evenodd">
-    <path d="M0,0 L0,3.2 L0,16 L16,16 L16,3.2 L16,0 L0,0 L0,0 L0,0 Z M2,14 L2,4 L14,4 L14,14 L2,14 L2,14 Z" id="Shape" fill="#000000"></path>
-    <polygon id="Shape" fill="#000000" points="6.47393799 12.9516602 10 9.41223145 10 12 11.9375 12 11.9375 6 6 6 6 8 8.5725708 8 5.05834961 11.5388794"></polygon>
-</svg>

--- a/src/svg/launch.svg
+++ b/src/svg/launch.svg
@@ -1,4 +1,0 @@
-<svg width="24px" height="20px" viewBox="0 0 24 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill-rule="evenodd">
-	<path d="M0,0 L0,4 L0,20 L24,20 L24,4 L24,0 L0,0 L0,0 Z M22,18 L2,18 L2,4 L22,4 L22,18 L22,18 Z" id="Shape" fill="#000000"></path>
-	<polygon id="Shape" fill="#000000" points="11.7 15.7 18 9.4 18 14 20 14 20 6 12 6 12 8 16.6 8 10.3 14.3"></polygon>
-</svg>


### PR DESCRIPTION
Will be replaced by newly drawn icons that extend outside the box.

Related to internal issue https://github.ibm.com/Bluemix/carbon-issues/issues/36