### PR TITLE
fix(build): removed arrow funcion from carbon-icons.js

### DIFF
--- a/gulp-tasks/build-data.js
+++ b/gulp-tasks/build-data.js
@@ -33,7 +33,7 @@ module.exports = () => readFilePromisified(`./dist/carbon-icons.svg`, { 'encodin
       })(this, function () {
         var icons = ${stringified};
         function camelCaseFromHyphnated(s) {
-          return s.replace(/\-+([A-z])/g, (match, token) => token.toUpperCase());
+          return s.replace(/\-+([A-z])/g, function (match, token) { return token.toUpperCase(); });
         }
         icons.forEach(function (item, i) {
           icons[camelCaseFromHyphnated(item.id)] = icons[i];


### PR DESCRIPTION
fixes #60 

Removed transpilers dependency replacing an arrow function with a normal function